### PR TITLE
Include usr/local/lib path to ldconfig command

### DIFF
--- a/www/pages/doc/begin.md
+++ b/www/pages/doc/begin.md
@@ -31,7 +31,7 @@ You have to setup a few things :
 
 - **On Windows** : Add the `c:\neko` directory to your `PATH` environment variable. Here are instructions for [Windows 2000](https://support.microsoft.com/en-us/kb/311843) and [Windows XP](https://support.microsoft.com/en-us/kb/310519).
 
-- **On Mac, Linux, and other Unix systems** : Put `neko`, `nekoc`, `nekoml`, and `nekotools` in `/usr/local/bin`. Put `libneko.so*` files in `/usr/local/lib`. Put `*.ndll` and `nekoml.std` in `/usr/local/lib/neko`. Put the `include/*.h` files in `/usr/local/include`. On Linux, you may have to run `sudo ldconfig` to refresh the library cache.
+- **On Mac, Linux, and other Unix systems** : Put `neko`, `nekoc`, `nekoml`, and `nekotools` in `/usr/local/bin`. Put `libneko.so*` files in `/usr/local/lib`. Put `*.ndll` and `nekoml.std` in `/usr/local/lib/neko`. Put the `include/*.h` files in `/usr/local/include`. On Linux, you may have to run `sudo ldconfig`  and `sudo ldconfig /usr/local/lib` to refresh the library cache.
 
 
 Once this is done you should be able to run the `neko` command from any directory. Please check that `neko` is working. (On Windows you can you can open a command terminal using `Start / Run..` and entering `cmd` then OK).


### PR DESCRIPTION
To have neko working in (Arch) Linux I needed to run `ldconfig` adding the path
`sudo ldconfig /usr/local/lib` (thanks @jonasmalacofilho).

According to man: ldconfig defaults are /lib and /usr/lib (/lib64 and /usr/lib64).

So I am proposing this addition to the "Instalation" page.

Thank you.

```
[acs@bohr build]$ sudo make install
...
...
-- Running: ldconfig
-- Installing: /usr/local/lib/neko/std.ndll
-- Installing: /usr/local/lib/neko/zlib.ndll
...
-- Installing: /usr/local/lib/neko/mod_tora2.ndll
[acs@bohr build]$ neko -v
neko: error while loading shared libraries: libneko.so.2: 
cannot open shared object file: No such file or directory
[acs@bohr build]$ ldd /usr/local/bin/neko
	linux-vdso.so.1 (0x00007ffcbd35e000)
	libneko.so.2 => not found
	libgc.so.1 => /usr/lib/libgc.so.1 (0x00007f9dd25e9000)
	libdl.so.2 => /usr/lib/libdl.so.2 (0x00007f9dd23e5000)
	libm.so.6 => /usr/lib/libm.so.6 (0x00007f9dd2099000)
	libpthread.so.0 => /usr/lib/libpthread.so.0 (0x00007f9dd1e7b000)
	libc.so.6 => /usr/lib/libc.so.6 (0x00007f9dd1ac4000)
	libatomic_ops.so.1 => /usr/lib/libatomic_ops.so.1 (0x00007f9dd18c1000)
	/lib64/ld-linux-x86-64.so.2 => /usr/lib64/ld-linux-x86-64.so.2 (0x00007f9dd2a58000)
[acs@bohr build]$ man ldconfig
[acs@bohr build]$ sudo ldconfig -v /usr/local/lib
[sudo] password for acs: 
ldconfig: Path `/usr/lib' given more than once
ldconfig: Path `/usr/lib64' given more than once
ldconfig: Can't stat /usr/libx32: No such file or directory
/usr/local/lib:
	libneko.so.2 -> libneko.so.2.1.0
/usr/lib:
....
```
