### PR TITLE
Remove year for copyright mention

### DIFF
--- a/views/Layout.html
+++ b/views/Layout.html
@@ -49,7 +49,7 @@
 			</div>
 
 			<div class="corpo">
-				<p>&copy; ::currentYear::
+				<p>&copy; 
 				<a href="https://haxe.org/foundation/" title="Haxe Foundation Website" class="hf-link">Haxe Foundation</a>
 				::if (editLink != null)::
 				| <a href="::editLink::" target="_blank" rel="external" class="edit-link" title="Use Github to suggest an edit to this page">Contribute to this page</a>


### PR DESCRIPTION
Year is not necessary for copyright mentions (https://daniel.haxx.se/blog/2023/01/08/copyright-without-years/) and is clearly not updating on https://nekovm.org, where it still shows "© 2019 [Haxe Foundation](https://haxe.org/foundation/)".

This solves both problems at once :wink: 